### PR TITLE
Removed = in instructions for Rails session_store initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ In the session_store initializer (config/initializers/session_store.rb):
 
 ```ruby
 # MongoMapper
-MyApp::Application.config.session_store = :mongo_mapper_store
+MyApp::Application.config.session_store :mongo_mapper_store
 
 # Mongoid
-MyApp::Application.config.session_store = :mongoid_store
+MyApp::Application.config.session_store :mongoid_store
 
 # anything else
-MyApp::Application.config.session_store = :mongo_store
+MyApp::Application.config.session_store :mongo_store
 MongoStore::Session.database = Mongo::Connection.new.db('my_app_development')
 ```
 


### PR DESCRIPTION
Hey, 

Noticed this when I added mongo_session_store to a project and copied the instructions from the readme. If you try to set `config.session_store` with a `=` the value will be ignored. Looks to work like this in rails 3.1 and 3.0. Let me know what you think!

Cheers

/Arvid
