### PR TITLE
Using autoload to require the different session stores 

### DIFF
--- a/lib/mongo_session_store-rails3.rb
+++ b/lib/mongo_session_store-rails3.rb
@@ -27,6 +27,6 @@ module MongoSessionStore
   self.collection_name = "sessions"
 end
 
-require 'mongo_session_store/mongo_mapper_store'
-require 'mongo_session_store/mongoid_store'
-require 'mongo_session_store/mongo_store'
+autoload :MongoMapperStore,'mongo_session_store/mongo_mapper_store'
+autoload :MongoidStore, 'mongo_session_store/mongoid_store'
+autoload :MongoStore, 'mongo_session_store/mongo_store'

--- a/lib/mongo_session_store/mongo_mapper_store.rb
+++ b/lib/mongo_session_store/mongo_mapper_store.rb
@@ -1,26 +1,22 @@
-begin
-  require 'mongo_mapper'
-  require 'mongo_session_store/mongo_store_base'
+require 'mongo_mapper'
+require 'mongo_session_store/mongo_store_base'
 
-  module ActionDispatch
-    module Session
-      class MongoMapperStore < MongoStoreBase
-        
-        class Session
-          include MongoMapper::Document
-          set_collection_name MongoSessionStore.collection_name
-          
-          key :_id,  String
-          key :data, Binary, :default => Marshal.dump({})
-          
-          timestamps!
-        end
-        
+module ActionDispatch
+  module Session
+    class MongoMapperStore < MongoStoreBase
+
+      class Session
+        include MongoMapper::Document
+        set_collection_name MongoSessionStore.collection_name
+
+        key :_id,  String
+        key :data, Binary, :default => Marshal.dump({})
+
+        timestamps!
       end
+
     end
   end
-
-  MongoMapperStore = ActionDispatch::Session::MongoMapperStore
-
-rescue LoadError
 end
+
+MongoMapperStore = ActionDispatch::Session::MongoMapperStore

--- a/lib/mongo_session_store/mongoid_store.rb
+++ b/lib/mongo_session_store/mongoid_store.rb
@@ -1,31 +1,27 @@
-begin
-  require 'mongoid'
-  require 'mongo_session_store/mongo_store_base'
+require 'mongoid'
+require 'mongo_session_store/mongo_store_base'
 
-  module ActionDispatch
-    module Session
-      class MongoidStore < MongoStoreBase
-        
-        class Session
-          include Mongoid::Document
-          include Mongoid::Timestamps
-          self.collection_name = MongoSessionStore.collection_name
-        
-          identity :type => String
+module ActionDispatch
+  module Session
+    class MongoidStore < MongoStoreBase
 
-          field :data, :type => BSON::Binary, :default => BSON::Binary.new(Marshal.dump({}))
-        end
+      class Session
+        include Mongoid::Document
+        include Mongoid::Timestamps
+        self.collection_name = MongoSessionStore.collection_name
 
-        private
-          def pack(data)
-            BSON::Binary.new(Marshal.dump(data))
-          end
-      
+        identity :type => String
+
+        field :data, :type => BSON::Binary, :default => BSON::Binary.new(Marshal.dump({}))
       end
+
+      private
+      def pack(data)
+        BSON::Binary.new(Marshal.dump(data))
+      end
+
     end
   end
-  
-  MongoidStore = ActionDispatch::Session::MongoidStore
-
-rescue LoadError
 end
+
+MongoidStore = ActionDispatch::Session::MongoidStore


### PR DESCRIPTION
I added `autoload` for requiring the session stores so you don't have to rescue on LoadError and not require files that is not used by the app using the gem. 
I guess it comes down to personal coding style/preferences about using `rescue LoadError` vs `autoload` for handling stuff like this =) What you think?
