### PR TITLE
Added support for running custom code before save session

### DIFF
--- a/lib/mongo_session_store/mongo_store_base.rb
+++ b/lib/mongo_session_store/mongo_store_base.rb
@@ -33,6 +33,10 @@ module ActionDispatch
         def set_session(env, sid, session_data, options = {})
           record = get_session_model(env, sid)
           record.data = pack(session_data)
+
+          # Custom code that runs (if defined) before the session is saved
+          record.before_save_session(env, sid, session_data, options) if record.respond_to?(:before_save_session)
+
           # Rack spec dictates that set_session should return true or false
           # depending on whether or not the session was saved or not.
           # However, ActionPack seems to want a session id instead.


### PR DESCRIPTION
A nice feature missing is to customize the Session class, adding attributes, indexes and another stuff useful to the application.

To do this you can simply add code to the class Session inside ActionDispatch::Session::MongoidStore (or the others stores available).
But inside this class you can use almost nothing of your app, like the environment or the session data (before it's converted to binary).

A simple solution is in this pull request: Add a call to a method called "before_save_session" passing the major variables availables: "env", "sid", "session_data" and "options". This method is suposed to be implemented by the application using this gem.

Now you can do this (if you're using warden) to save the user_id in the session:

``` ruby
module ActionDispatch
  module Session
    class MongoidStore < MongoStoreBase
      class Session

        field :user_id, :type => Moped::BSON::ObjectId
        index({ user_id: 1 })

        def before_save_session(env, sid, session_data, options)
          puts "before_save_session"
          if !self.user_id && env['warden'] && env['warden'].user
            self.user_id = env['warden'].user._id
          end
        end

      end
    end
  end
end
```

With the user_id in the session (in database) you can do fun things like remove all sessions from a specific user.

Cheers
