### PR TITLE
Remove bson_ext gem when using Mongoid

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :development, :test do
   gem 'rake'
   if !ENV['MONGO_SESSION_STORE_ORM'] || ENV['MONGO_SESSION_STORE_ORM'] == 'mongo_mapper'
     gem 'mongo_mapper', '>= 0.10.1'
+    gem 'bson_ext',      MONGO_VERS, :platforms => :ruby
   end
 
   if !ENV['MONGO_SESSION_STORE_ORM'] || ENV['MONGO_SESSION_STORE_ORM'] == 'mongoid'
@@ -27,8 +28,8 @@ group :development, :test do
 
   if !ENV['MONGO_SESSION_STORE_ORM'] || ENV['MONGO_SESSION_STORE_ORM'] == 'mongo'
     gem 'mongo',         MONGO_VERS
+    gem 'bson_ext',      MONGO_VERS, :platforms => :ruby
   end
-  gem 'bson_ext',      MONGO_VERS, :platforms => :ruby
 
   gem 'system_timer', :platforms => :ruby_18
   gem 'rbx-require-relative', '0.0.5', :platforms => :ruby_18


### PR DESCRIPTION
Mongoid3 no longer uses the bson_ext gem, in preference to its own
Moped::BSON implementation.
http://mongoid.org/en/mongoid/docs/upgrading.html

One of my co-workers also found a performance problem when mongoid3 and bson_ext are used https://github.com/brianhempel/mongo_session_store/issues/18.
I think that this change will resolve that issue.
