### PR TITLE
Add missing dependency on moped

### DIFF
--- a/lib/mongo_session_store/mongoid_store.rb
+++ b/lib/mongo_session_store/mongoid_store.rb
@@ -1,5 +1,6 @@
 require 'mongoid'
 require 'mongo_session_store/mongo_store_base'
+require 'moped'
 
 module ActionDispatch
   module Session

--- a/mongo_session_store-rails3.gemspec
+++ b/mongo_session_store-rails3.gemspec
@@ -14,4 +14,5 @@ Gem::Specification.new do |s|
   s.summary          = "Rails session stores for MongoMapper, Mongoid, or any other ODM. Rails 3.1 and 3.2 compatible."
 
   s.add_dependency "actionpack", ">= 3.1"
+  s.add_dependency "moped"
 end


### PR DESCRIPTION
Here's an example stack trace:

```
/var/lib/gems/1.9.1/gems/mongo_session_store-rails3-4.1.1/lib/mongo_session_store/mongoid_store.rb:16:in `<class:Session>': uninitialized constant Moped::BSON (NameError)
        from /var/lib/gems/1.9.1/gems/mongo_session_store-rails3-4.1.1/lib/mongo_session_store/mongoid_store.rb:8:in `<class:MongoidStore>'
        from /var/lib/gems/1.9.1/gems/mongo_session_store-rails3-4.1.1/lib/mongo_session_store/mongoid_store.rb:6:in `<module:Session>'
        from /var/lib/gems/1.9.1/gems/mongo_session_store-rails3-4.1.1/lib/mongo_session_store/mongoid_store.rb:5:in `<module:ActionDispatch>'
        from /var/lib/gems/1.9.1/gems/mongo_session_store-rails3-4.1.1/lib/mongo_session_store/mongoid_store.rb:4:in `<top (required)>'
        from /var/lib/gems/1.9.1/gems/mongo_session_store-rails3-4.1.1/lib/mongo_session_store-rails3.rb:41:in `block in <top (required)>'
        from /var/lib/gems/1.9.1/gems/mongo_session_store-rails3-4.1.1/lib/mongo_session_store-rails3.rb:39:in `each'
        from /var/lib/gems/1.9.1/gems/mongo_session_store-rails3-4.1.1/lib/mongo_session_store-rails3.rb:39:in `<top (required)>'
```
