### PR TITLE
Provide overwrite option when overwriting _id field in MongoidStore

### DIFF
--- a/lib/mongo_session_store/mongoid_store.rb
+++ b/lib/mongo_session_store/mongoid_store.rb
@@ -12,7 +12,7 @@ module ActionDispatch
 
         store_in :collection => MongoSessionStore.collection_name
 
-        field :_id, :type => String
+        field :_id, :type => String, :overwrite => true
         field :data, :type => BINARY_CLASS, :default => -> { marshaled_binary({}) }
         attr_accessible :_id, :data if respond_to?(:attr_accessible)
 


### PR DESCRIPTION
When using the MongoidStore there is a warning in the logs:

> WARN -- : Overwriting existing field _id in class ActionDispatch::Session::MongoidStore::Session.

Mongoid has an `overwrite` option to omit the warning when overwriting existing fields.
