### PR TITLE
Only use overwrite option when available

### DIFF
--- a/lib/mongo_session_store/mongoid_store.rb
+++ b/lib/mongo_session_store/mongoid_store.rb
@@ -12,7 +12,11 @@ module ActionDispatch
 
         store_in :collection => MongoSessionStore.collection_name
 
-        field :_id, :type => String, :overwrite => true
+        if Mongoid::Fields::Validators::Macro::OPTIONS.include? :overwrite
+          field :_id, :type => String, :overwrite => true
+        else
+          field :_id, :type => String
+        end
         field :data, :type => BINARY_CLASS, :default => -> { marshaled_binary({}) }
         attr_accessible :_id, :data if respond_to?(:attr_accessible)
 


### PR DESCRIPTION
I just realized that the `overwrite` option from my last pull request was just introduced with Mongoid 4.

This change checks if the option is available first, to keep compatibility with Mongoid 3.
