### PR TITLE
Add license to gemspecs

### DIFF
--- a/mongo_session_store-rails3.gemspec
+++ b/mongo_session_store-rails3.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |s|
   s.files            = `git ls-files`.split("\n")
   s.test_files       = `git ls-files -- {test,spec,features,perf}/*`.split("\n")
   s.homepage         = "http://github.com/brianhempel/mongo_session_store"
+  s.license          = "MIT"
   s.require_paths    = ["lib"]
   s.rubygems_version = "1.3.7"
   s.summary          = "Rails session stores for MongoMapper, Mongoid, or any other ODM. Rails 3.1, 3.2, 4.0, and 4.1 compatible."

--- a/mongo_session_store-rails4.gemspec
+++ b/mongo_session_store-rails4.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |s|
   s.files            = `git ls-files`.split("\n")
   s.test_files       = `git ls-files -- {test,spec,features,perf}/*`.split("\n")
   s.homepage         = "http://github.com/brianhempel/mongo_session_store"
+  s.license          = "MIT"
   s.require_paths    = ["lib"]
   s.rubygems_version = "1.3.7"
   s.summary          = "Rails session stores for MongoMapper, Mongoid, or any other ODM. Rails 3.1, 3.2, 4.0, and 4.1 compatible."


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.